### PR TITLE
noSuggestionsNode prop for suggetions lists

### DIFF
--- a/demo/components/AutoComplete/Strings.tsx
+++ b/demo/components/AutoComplete/Strings.tsx
@@ -27,12 +27,13 @@ export const Strings = (componentProps: any) => {
           'Budapest',
           'Ottawa',
           'Moscow',
+          'kljljl'
         ]}
         value={value}
         invalidMessage="invalidMessage"
         requiredMessage="requiredMessage"
-        shouldCorrectValue
-        minSearchLength={3}
+        minSearchLength={1}
+        isOpen
         onChange={(ev) => {
           setValue(ev.component.value);
           update('Change', ev);
@@ -47,6 +48,7 @@ export const Strings = (componentProps: any) => {
           update('Blur', ev);
         }}
         isRequired
+        noSuggestionsNode='Nothing found'
         _width30
         {...props}
       />

--- a/demo/components/AutoComplete/Strings.tsx
+++ b/demo/components/AutoComplete/Strings.tsx
@@ -47,7 +47,7 @@ export const Strings = (componentProps: any) => {
           update('Blur', ev);
         }}
         isRequired
-        noSuggestionsNode={<>
+        noSuggestionsText={<>
           Nothing found
           <L.Icon
             icon={L.IconTypes.Icons.Frown}

--- a/demo/components/AutoComplete/Strings.tsx
+++ b/demo/components/AutoComplete/Strings.tsx
@@ -27,13 +27,12 @@ export const Strings = (componentProps: any) => {
           'Budapest',
           'Ottawa',
           'Moscow',
-          'kljljl'
         ]}
         value={value}
         invalidMessage="invalidMessage"
         requiredMessage="requiredMessage"
-        minSearchLength={1}
-        isOpen
+        shouldCorrectValue
+        minSearchLength={3}
         onChange={(ev) => {
           setValue(ev.component.value);
           update('Change', ev);
@@ -48,7 +47,16 @@ export const Strings = (componentProps: any) => {
           update('Blur', ev);
         }}
         isRequired
-        noSuggestionsNode='Nothing found'
+        noSuggestionsNode={<>
+          Nothing found
+          <L.Icon
+            icon={L.IconTypes.Icons.Frown}
+            size={18}
+            strokeWidth={1}
+            _margin-left
+          />
+        </>}
+        isOpen
         _width30
         {...props}
       />

--- a/leda/components/AutoComplete/index.tsx
+++ b/leda/components/AutoComplete/index.tsx
@@ -57,7 +57,7 @@ export const AutoComplete = React.forwardRef((props: AutoCompleteProps, ref: Rea
     listRender,
     minSearchLength,
     name,
-    noSuggestionsNode,
+    noSuggestionsText,
     noSuggestionsRender,
     onBlur,
     onChange,
@@ -241,7 +241,7 @@ export const AutoComplete = React.forwardRef((props: AutoCompleteProps, ref: Rea
         isOpen={isSuggestionsListOpen}
         itemRender={itemRender}
         listRender={listRender}
-        noSuggestionsNode={noSuggestionsNode}
+        noSuggestionsText={noSuggestionsText}
         noSuggestionsRender={noSuggestionsRender}
         onClick={suggestionClickHandler}
         placeholder={placeholder}

--- a/leda/components/AutoComplete/index.tsx
+++ b/leda/components/AutoComplete/index.tsx
@@ -57,6 +57,7 @@ export const AutoComplete = React.forwardRef((props: AutoCompleteProps, ref: Rea
     listRender,
     minSearchLength,
     name,
+    noSuggestionsNode,
     noSuggestionsRender,
     onBlur,
     onChange,
@@ -240,6 +241,7 @@ export const AutoComplete = React.forwardRef((props: AutoCompleteProps, ref: Rea
         isOpen={isSuggestionsListOpen}
         itemRender={itemRender}
         listRender={listRender}
+        noSuggestionsNode={noSuggestionsNode}
         noSuggestionsRender={noSuggestionsRender}
         onClick={suggestionClickHandler}
         placeholder={placeholder}

--- a/leda/components/AutoComplete/types.ts
+++ b/leda/components/AutoComplete/types.ts
@@ -131,7 +131,7 @@ export interface AutoCompleteProps<T extends Suggestion = Suggestion> extends Va
   /** Имя поля ввода */
   name?: string,
   /** This will be shown when no suggestions are found */
-  noSuggestionsNode?: React.ReactNode,
+  noSuggestionsText?: React.ReactNode,
   /** Принимает JSX */
   noSuggestionsRender?: SuggestionListProps['noSuggestionsRender'],
   /** Обработчик события потери фокуса */

--- a/leda/components/AutoComplete/types.ts
+++ b/leda/components/AutoComplete/types.ts
@@ -130,6 +130,8 @@ export interface AutoCompleteProps<T extends Suggestion = Suggestion> extends Va
   minSearchLength?: number,
   /** Имя поля ввода */
   name?: string,
+  /** This will be shown when no suggestions are found */
+  noSuggestionsNode?: React.ReactNode,
   /** Принимает JSX */
   noSuggestionsRender?: SuggestionListProps['noSuggestionsRender'],
   /** Обработчик события потери фокуса */

--- a/leda/components/DropDownSelect/index.tsx
+++ b/leda/components/DropDownSelect/index.tsx
@@ -50,7 +50,7 @@ export const DropDownSelect = React.forwardRef((props: DropDownSelectProps, ref:
     itemRender,
     listRender,
     name,
-    noSuggestionsNode,
+    noSuggestionsText,
     noSuggestionsRender,
     onBlur,
     onChange,
@@ -210,7 +210,7 @@ export const DropDownSelect = React.forwardRef((props: DropDownSelectProps, ref:
         isOpen={isDisabled ? false : isOpen}
         itemRender={itemRender}
         listRender={listRender}
-        noSuggestionsNode={noSuggestionsNode}
+        noSuggestionsText={noSuggestionsText}
         noSuggestionsRender={noSuggestionsRender}
         onClick={handleChange}
         placeholder={placeholder}

--- a/leda/components/DropDownSelect/index.tsx
+++ b/leda/components/DropDownSelect/index.tsx
@@ -50,6 +50,7 @@ export const DropDownSelect = React.forwardRef((props: DropDownSelectProps, ref:
     itemRender,
     listRender,
     name,
+    noSuggestionsNode,
     noSuggestionsRender,
     onBlur,
     onChange,
@@ -209,6 +210,7 @@ export const DropDownSelect = React.forwardRef((props: DropDownSelectProps, ref:
         isOpen={isDisabled ? false : isOpen}
         itemRender={itemRender}
         listRender={listRender}
+        noSuggestionsNode={noSuggestionsNode}
         noSuggestionsRender={noSuggestionsRender}
         onClick={handleChange}
         placeholder={placeholder}

--- a/leda/components/DropDownSelect/types.ts
+++ b/leda/components/DropDownSelect/types.ts
@@ -74,7 +74,7 @@ export interface DropDownSelectProps<T extends Value = Value> extends Validation
   itemRender?: SuggestionListProps['itemRender'],
   listRender?: SuggestionListProps['listRender'],
   /** This will be shown when no suggestions are found */
-  noSuggestionsNode?: React.ReactNode,
+  noSuggestionsText?: React.ReactNode,
   noSuggestionsRender?: SuggestionListProps['noSuggestionsRender'],
   onBlur?: CustomEventHandler<BlurEvent<T>>,
   onChange?: CustomEventHandler<ChangeEvent<T>>,

--- a/leda/components/DropDownSelect/types.ts
+++ b/leda/components/DropDownSelect/types.ts
@@ -73,6 +73,8 @@ export interface DropDownSelectProps<T extends Value = Value> extends Validation
   isOpen?: boolean,
   itemRender?: SuggestionListProps['itemRender'],
   listRender?: SuggestionListProps['listRender'],
+  /** This will be shown when no suggestions are found */
+  noSuggestionsNode?: React.ReactNode,
   noSuggestionsRender?: SuggestionListProps['noSuggestionsRender'],
   onBlur?: CustomEventHandler<BlurEvent<T>>,
   onChange?: CustomEventHandler<ChangeEvent<T>>,

--- a/leda/components/MultiSelect/index.tsx
+++ b/leda/components/MultiSelect/index.tsx
@@ -55,6 +55,7 @@ export const MultiSelect = React.forwardRef((props: MultiSelectProps, ref: React
     maxSelected,
     maxTags,
     name,
+    noSuggestionsNode,
     noSuggestionsRender,
     onBlur,
     onChange,
@@ -314,6 +315,7 @@ export const MultiSelect = React.forwardRef((props: MultiSelectProps, ref: React
           isOpen={isNil(isOpen) ? isFocused : isOpen}
           itemRender={hasCheckBoxes ? checkBoxesRender : itemRender}
           listRender={listRender}
+          noSuggestionsNode={noSuggestionsNode}
           noSuggestionsRender={noSuggestionsRender}
           onClick={handleSelect}
           selectAllItemRender={selectAllItemRender}

--- a/leda/components/MultiSelect/index.tsx
+++ b/leda/components/MultiSelect/index.tsx
@@ -55,7 +55,7 @@ export const MultiSelect = React.forwardRef((props: MultiSelectProps, ref: React
     maxSelected,
     maxTags,
     name,
-    noSuggestionsNode,
+    noSuggestionsText,
     noSuggestionsRender,
     onBlur,
     onChange,
@@ -315,7 +315,7 @@ export const MultiSelect = React.forwardRef((props: MultiSelectProps, ref: React
           isOpen={isNil(isOpen) ? isFocused : isOpen}
           itemRender={hasCheckBoxes ? checkBoxesRender : itemRender}
           listRender={listRender}
-          noSuggestionsNode={noSuggestionsNode}
+          noSuggestionsText={noSuggestionsText}
           noSuggestionsRender={noSuggestionsRender}
           onClick={handleSelect}
           selectAllItemRender={selectAllItemRender}

--- a/leda/components/MultiSelect/types.ts
+++ b/leda/components/MultiSelect/types.ts
@@ -119,7 +119,7 @@ export interface MultiSelectProps<T extends MultiSelectValue | null | undefined 
   /** Имя компонента */
   name?: string,
   /** This will be shown when no suggestions are found */
-  noSuggestionsNode?: React.ReactNode,
+  noSuggestionsText?: React.ReactNode,
   /** Атрибут рендера выпадающего списка, если в data нет значений, равных содержимому инпута. Принимает JSX */
   noSuggestionsRender?: any,
   /** Обработчик события потери фокуса */

--- a/leda/components/MultiSelect/types.ts
+++ b/leda/components/MultiSelect/types.ts
@@ -118,6 +118,8 @@ export interface MultiSelectProps<T extends MultiSelectValue | null | undefined 
   maxTags?: number,
   /** Имя компонента */
   name?: string,
+  /** This will be shown when no suggestions are found */
+  noSuggestionsNode?: React.ReactNode,
   /** Атрибут рендера выпадающего списка, если в data нет значений, равных содержимому инпута. Принимает JSX */
   noSuggestionsRender?: any,
   /** Обработчик события потери фокуса */

--- a/leda/src/SuggestionList/NoSuggestions.tsx
+++ b/leda/src/SuggestionList/NoSuggestions.tsx
@@ -2,6 +2,6 @@ import * as React from 'react';
 import { Div } from '../../components/Div';
 import { NoSuggestionsProps } from './types';
 
-export const NoSuggestions = ({ className, noSuggestionsNode = null }: NoSuggestionsProps): React.ReactElement => (
-  <Div className={className}>{ noSuggestionsNode }</Div>
+export const NoSuggestions = ({ className, noSuggestionsText = null }: NoSuggestionsProps): React.ReactElement => (
+  <Div className={className}>{ noSuggestionsText }</Div>
 );

--- a/leda/src/SuggestionList/NoSuggestions.tsx
+++ b/leda/src/SuggestionList/NoSuggestions.tsx
@@ -2,6 +2,6 @@ import * as React from 'react';
 import { Div } from '../../components/Div';
 import { NoSuggestionsProps } from './types';
 
-export const NoSuggestions = ({ className }: NoSuggestionsProps): React.ReactElement => (
-  <Div className={className}>Ничего не найдено</Div>
+export const NoSuggestions = ({ className, noSuggestionsNode = null }: NoSuggestionsProps): React.ReactElement => (
+  <Div className={className}>{ noSuggestionsNode }</Div>
 );

--- a/leda/src/SuggestionList/SuggestionList.tsx
+++ b/leda/src/SuggestionList/SuggestionList.tsx
@@ -24,7 +24,7 @@ export const SuggestionList = (props: SuggestionListProps): React.ReactElement |
     isOpen,
     itemRender,
     listRender,
-    noSuggestionsNode,
+    noSuggestionsText,
     noSuggestionsRender,
     onClick,
     placeholder,
@@ -153,7 +153,7 @@ export const SuggestionList = (props: SuggestionListProps): React.ReactElement |
   if (!data?.length) {
     return (
       <Div className={theme.container} onMouseDown={(ev) => ev.preventDefault()} ref={wrapperRef}>
-        <NoSuggestionsComponent className={theme.noSuggestions} noSuggestionsNode={noSuggestionsNode} />
+        <NoSuggestionsComponent className={theme.noSuggestions} noSuggestionsText={noSuggestionsText} />
       </Div>
     );
   }

--- a/leda/src/SuggestionList/SuggestionList.tsx
+++ b/leda/src/SuggestionList/SuggestionList.tsx
@@ -24,6 +24,7 @@ export const SuggestionList = (props: SuggestionListProps): React.ReactElement |
     isOpen,
     itemRender,
     listRender,
+    noSuggestionsNode,
     noSuggestionsRender,
     onClick,
     placeholder,
@@ -152,7 +153,7 @@ export const SuggestionList = (props: SuggestionListProps): React.ReactElement |
   if (!data?.length) {
     return (
       <Div className={theme.container} onMouseDown={(ev) => ev.preventDefault()} ref={wrapperRef}>
-        <NoSuggestionsComponent className={theme.noSuggestions} />
+        <NoSuggestionsComponent className={theme.noSuggestions} noSuggestionsNode={noSuggestionsNode} />
       </Div>
     );
   }

--- a/leda/src/SuggestionList/types.ts
+++ b/leda/src/SuggestionList/types.ts
@@ -30,6 +30,7 @@ export interface SuggestionListProps {
   isOpen: boolean,
   itemRender?: CustomRender<SuggestionItemProps, {}, SuggestionElementProps>,
   listRender?: CustomRender<SuggestionListProps, {}, UlProps>,
+  noSuggestionsNode?: React.ReactNode,
   noSuggestionsRender?: CustomRender<SuggestionListProps, {}, NoSuggestionsProps>,
   onClick?: CustomEventHandler<React.MouseEvent<HTMLElement> & SuggestionTarget>,
   placeholder?: string,
@@ -67,6 +68,7 @@ export interface SuggestionItemProps {
 }
 
 export interface NoSuggestionsProps {
+  noSuggestionsNode?: React.ReactNode,
   className?: string,
 }
 

--- a/leda/src/SuggestionList/types.ts
+++ b/leda/src/SuggestionList/types.ts
@@ -30,7 +30,7 @@ export interface SuggestionListProps {
   isOpen: boolean,
   itemRender?: CustomRender<SuggestionItemProps, {}, SuggestionElementProps>,
   listRender?: CustomRender<SuggestionListProps, {}, UlProps>,
-  noSuggestionsNode?: React.ReactNode,
+  noSuggestionsText?: React.ReactNode,
   noSuggestionsRender?: CustomRender<SuggestionListProps, {}, NoSuggestionsProps>,
   onClick?: CustomEventHandler<React.MouseEvent<HTMLElement> & SuggestionTarget>,
   placeholder?: string,
@@ -68,7 +68,7 @@ export interface SuggestionItemProps {
 }
 
 export interface NoSuggestionsProps {
-  noSuggestionsNode?: React.ReactNode,
+  noSuggestionsText?: React.ReactNode,
   className?: string,
 }
 

--- a/styles/themes/light/components/SuggestionList/_suggestion-list.scss
+++ b/styles/themes/light/components/SuggestionList/_suggestion-list.scss
@@ -25,7 +25,6 @@
       font-weight: lighter;
       font-family: "roboto", sans-serif;
       font-size: 16px;
-      text-transform: uppercase;
       color: $black-03;
     }
 


### PR DESCRIPTION
Add noSuggestionsNode prop to let users add their own content for an empty list when no suggestions are found.

Previous behaviour was to render НИЧЕГО НЕ НАЙДЕНО

Empty list is default behaviour now.